### PR TITLE
优化Docker部署脚本的PM2目录映射

### DIFF
--- a/scripts/deploy-qronos.sh
+++ b/scripts/deploy-qronos.sh
@@ -741,7 +741,7 @@ setup_data_directories() {
     
     # 创建必要的数据目录
     log_info "创建数据目录..."
-    mkdir -p ./data/qronos/data ./data/qronos/logs ./data/firm ./data/.pm2
+    mkdir -p ./data/qronos/data ./data/qronos/logs ./data/firm ./data/.pm2-runtime
     
     # 检测操作系统并设置权限
     log_info "设置目录权限..."
@@ -1410,7 +1410,7 @@ deploy_container() {
         -v $(pwd)/data/qronos/data:/app/qronos/data \
         -v $(pwd)/data/qronos/logs:/app/qronos/logs \
         -v $(pwd)/data/firm:/app/firm \
-        -v $(pwd)/data/.pm2:/app/.pm2"
+        -v $(pwd)/data/.pm2-runtime:/app/.pm2-runtime"
     
     # 在Linux系统上添加用户权限配置
     if [[ "$(uname)" == "Linux" ]] && [[ -n "$CURRENT_UID" ]]; then


### PR DESCRIPTION
优化Docker部署脚本的PM2目录映射

🎯 问题：原有的 .pm2 映射是无效的，因为容器中该目录根本不存在，导致无法在宿主机访问PM2的配置和日志。

🔧 解决方案：
- 删除：`-v $(pwd)/data/.pm2:/app/.pm2` 无效的目录映射
- 添加：`-v $(pwd)/data/.pm2-runtime:/app/.pm2-runtime` 映射实际存在的PM2目录
- 简化：只创建实际需要的目录

✅ 效果：
- 🎯 可在宿主机访问完整的PM2配置、日志和进程信息
- 🚀 移除无效映射，简化Docker配置
- 💾 不影响容器内PM2正常运行

## 📋 技术细节
- PM2应用日志通过现有的 `firm` 目录映射访问
- PM2系统配置和日志通过新增的 `.pm2-runtime` 映射访问
- 删除的 `.pm2` 映射指向不存在的目录，完全无效